### PR TITLE
🔧 fix(server.go): rename auth_service package to authservice to follo…

### DIFF
--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	auth_service "github.com/BerryTracer/auth-service/grpc/proto"
+	authservice "github.com/BerryTracer/auth-service/grpc/proto"
 	gen "github.com/BerryTracer/device-service/grpc/proto"
 	"github.com/BerryTracer/device-service/model"
 	"github.com/BerryTracer/device-service/service"
@@ -16,11 +16,11 @@ import (
 
 type DeviceGrpcServer struct {
 	DeviceService service.DeviceService
-	AuthService   auth_service.AuthServiceClient
+	AuthService   authservice.AuthServiceClient
 	gen.UnimplementedDeviceServiceServer
 }
 
-func NewDeviceGrpcServer(deviceService service.DeviceService, authService auth_service.AuthServiceClient) *DeviceGrpcServer {
+func NewDeviceGrpcServer(deviceService service.DeviceService, authService authservice.AuthServiceClient) *DeviceGrpcServer {
 	return &DeviceGrpcServer{
 		DeviceService: deviceService,
 		AuthService:   authService,
@@ -52,7 +52,7 @@ func (s *DeviceGrpcServer) CreateDevice(ctx context.Context, req *gen.CreateDevi
 	}
 
 	token := md["authorization"][0]
-	tokenResults, err := s.AuthService.VerifyToken(ctx, &auth_service.VerifyTokenRequest{
+	tokenResults, err := s.AuthService.VerifyToken(ctx, &authservice.VerifyTokenRequest{
 		Token: token,
 	})
 
@@ -75,7 +75,10 @@ func (s *DeviceGrpcServer) CreateDevice(ctx context.Context, req *gen.CreateDevi
 		BatteryLevel:     int(req.Device.BatteryLevel),
 	}
 
-	s.DeviceService.CreateDevice(ctx, device)
+	err = s.DeviceService.CreateDevice(ctx, device)
+	if err != nil {
+		return nil, err
+	}
 
 	return &gen.DeviceResponse{
 		Id:      device.ID,

--- a/repository/device_repository_test.go
+++ b/repository/device_repository_test.go
@@ -208,7 +208,7 @@ func TestDeviceMongoRepository_GetDeviceById_Error(t *testing.T) {
 	_, err := repo.GetDeviceById(ctx, testID)
 
 	// Check if the error is not nil and is the expected error.
-	if err != mongo.ErrNoDocuments {
+	if !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Errorf("expected mongo.ErrNoDocuments, got %v", err)
 	}
 }
@@ -382,7 +382,7 @@ func TestDeviceMongoRepository_GetDeviceBySerialNumber_Error(t *testing.T) {
 	_, err := repo.GetDeviceBySerialNumber(ctx, serialNumber)
 
 	// Check for error.
-	if err != mongo.ErrNoDocuments {
+	if !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Errorf("expected mongo.ErrNoDocuments, got %v", err)
 	}
 }

--- a/service/device_service_test.go
+++ b/service/device_service_test.go
@@ -46,10 +46,10 @@ func TestDeviceService_CreateDevice(t *testing.T) {
 	repository := new(DeviceRepositoryMock)
 	repository.On("CreateDevice", mock.Anything, device).Return(nil)
 
-	service := service.NewDeviceService(repository)
+	deviceService := service.NewDeviceService(repository)
 
 	// Act
-	err := service.CreateDevice(context.Background(), device)
+	err := deviceService.CreateDevice(context.Background(), device)
 
 	// Assert
 	if err != nil {
@@ -68,10 +68,10 @@ func TestDeviceService_GetDeviceById(t *testing.T) {
 	repository := new(DeviceRepositoryMock)
 	repository.On("GetDeviceById", mock.Anything, device.ID).Return(device, nil)
 
-	service := service.NewDeviceService(repository)
+	deviceService := service.NewDeviceService(repository)
 
 	// Act
-	result, err := service.GetDeviceById(context.Background(), device.ID)
+	result, err := deviceService.GetDeviceById(context.Background(), device.ID)
 
 	// Assert
 	if err != nil {
@@ -94,10 +94,10 @@ func TestDeviceService_GetDeviceBySerialNumber(t *testing.T) {
 	repository := new(DeviceRepositoryMock)
 	repository.On("GetDeviceBySerialNumber", mock.Anything, device.SerialNumber).Return(device, nil)
 
-	service := service.NewDeviceService(repository)
+	deviceService := service.NewDeviceService(repository)
 
 	// Act
-	result, err := service.GetDeviceBySerialNumber(context.Background(), device.SerialNumber)
+	result, err := deviceService.GetDeviceBySerialNumber(context.Background(), device.SerialNumber)
 
 	// Assert
 	if err != nil {
@@ -120,10 +120,10 @@ func TestDeviceService_GetDevicesByUserId(t *testing.T) {
 	repository := new(DeviceRepositoryMock)
 	repository.On("GetDevicesByUserId", mock.Anything, device.UserID).Return([]*model.Device{device}, nil)
 
-	service := service.NewDeviceService(repository)
+	deviceService := service.NewDeviceService(repository)
 
 	// Act
-	result, err := service.GetDevicesByUserId(context.Background(), device.UserID)
+	result, err := deviceService.GetDevicesByUserId(context.Background(), device.UserID)
 
 	// Assert
 	if err != nil {


### PR DESCRIPTION
…w Go naming conventions

🔧 fix(main.go): rename auth_service package to authservice to follow Go naming conventions
🔧 fix(device_repository_test.go): use errors.Is to check for mongo.ErrNoDocuments error
🔧 fix(device_service_test.go): rename service variable to deviceService for clarity